### PR TITLE
Fix code deprecations

### DIFF
--- a/lib/console.coffee
+++ b/lib/console.coffee
@@ -155,7 +155,7 @@ module.exports =
     @input.on 'keydown', (e) => @inputKeydownHandler(e)
     @input.on 'keyup', (e) => @inputKeyupHandler(e)
 
-    @cwd = atom.project.getPath()
+    @cwd = atom.project.getPaths()[0]
     @env = process.env
     @clearInputText()
 
@@ -299,7 +299,7 @@ module.exports =
           @addOutput data.toString()
 
         @child.on 'close', =>
-          atom.project.getRepo()?.refreshStatus() if command.file is 'git'
+          atom.project.getRepositories()[0]?.refreshStatus() if command.file is 'git'
           @closeChild()
 
         @child.on 'error', =>


### PR DESCRIPTION
Fix some deprecated codes showing up on the editor

Atom deprecation warnings:

Use ::getRepositories instead

```
Project.getRepo (<PATH>\AppData\Local\atom\app-0.189.0\resources\app\src\project.js:189:12)
ChildProcess.<anonymous> (<PATH>\.atom\packages\git-go\lib\console.coffee:400:43)
```

Use ::getPaths instead

```
Project.getPath (<PATH>\AppData\Local\atom\app-0.189.0\resources\app\src\project.js:235:12)
Object.initialize (<PATH>\.atom\packages\git-go\lib\console.coffee:158:24)
```
